### PR TITLE
Sliots/scoop-bucket 更名为 sliots/ScoopBucket

### DIFF
--- a/bucket-not-recommand.txt
+++ b/bucket-not-recommand.txt
@@ -1,3 +1,4 @@
 anderlli0053/DEV-tools
 L-Trump/scoop-raresoft
 arch3rPro/PST-Bucket
+Sliots/scoop-bucket

--- a/bucket-recommand.txt
+++ b/bucket-recommand.txt
@@ -1,6 +1,6 @@
 kkzzhizhou/scoop-zapps
 HCLonely/my-scoop-bucket
 Weidows-projects/scoop-3rd
-Sliots/scoop-bucket
 SayCV/scoop-cvp
 ScoopInstaller/PHP
+sliots/ScoopBucket


### PR DESCRIPTION
原账号状态异常已注销，因此 Sliots/scoop-bucket 更名为 sliots/ScoopBucket